### PR TITLE
Fix for login problem sending users to the wrong region

### DIFF
--- a/Grid/lib/Class.GetScene.php
+++ b/Grid/lib/Class.GetScene.php
@@ -45,6 +45,7 @@ class GetScene implements IGridService
         
         if (isset($params["SceneID"]) && UUID::TryParse($params["SceneID"], $this->SceneID))
         {
+            log_message('debug',"GetScene by SceneID " . $params["SceneID"]);
             $sql = "SELECT ID, Name, Address, Enabled, ExtraData, LastUpdate,
                     CONCAT('<', MinX, ',', MinY, ',', MinZ, '>') AS MinPosition,  
                     CONCAT('<', MaxX, ',', MaxY, ',', MaxZ, '>') AS MaxPosition
@@ -55,6 +56,7 @@ class GetScene implements IGridService
         }
         else if (isset($params["Name"]))
         {
+            log_message('debug',"GetScene by Name " . $params["Name"]);
             $sql = "SELECT ID, Name, Address, Enabled, ExtraData, LastUpdate,
                     CONCAT('<', MinX, ',', MinY, ',', MinZ, '>') AS MinPosition,  
                     CONCAT('<', MaxX, ',', MaxY, ',', MaxZ, '>') AS MaxPosition
@@ -62,8 +64,6 @@ class GetScene implements IGridService
 
             if (isset($params["Enabled"]) && $params["Enabled"])
                 $sql .= " AND Enabled=1";
-
-            log_message('error',"Get Name SQL: " . $sql);
 
         }
         else if (isset($params["Position"]) && Vector3::TryParse($params["Position"], $this->Position))

--- a/Grid/login/index.php
+++ b/Grid/login/index.php
@@ -292,14 +292,13 @@ function lookup_scene_by_name($name)
     $gridService = $config['grid_service'];
     
     $response = webservice_post($gridService, array(
-        'RequestMethod' => 'GetScenes',
+        'RequestMethod' => 'GetScene',
         'NameQuery' => $name,
-        'Enabled' => '1',
-        'MaxNumber' => '1')
+        'Enabled' => '1')
     );
     
-    if (!empty($response['Success']) && is_array($response['Scenes']) && count($response['Scenes']) > 0)
-        return Scene::fromOSD($response['Scenes'][0]);
+    if (!empty($response['Success']))
+        return Scene::fromOSD($response);
     
     return null;
 }

--- a/Grid/login/index.php
+++ b/Grid/login/index.php
@@ -293,7 +293,7 @@ function lookup_scene_by_name($name)
     
     $response = webservice_post($gridService, array(
         'RequestMethod' => 'GetScene',
-        'NameQuery' => $name,
+        'Name' => $name,
         'Enabled' => '1')
     );
     


### PR DESCRIPTION
Login has used a substring match at login and sends users to the first matching region instead of using an exact match. It's made some regions impossible to login to based on unpredictable database query result ordering.
